### PR TITLE
feat: add --notes/-n option for task descriptions

### DIFF
--- a/src/reclaim/commands/create-task.py
+++ b/src/reclaim/commands/create-task.py
@@ -25,6 +25,14 @@ class CreateTaskCommand(Command):
         )
 
         subparser.add_argument(
+            "-n",
+            "--notes",
+            type=str,
+            metavar="<text>",
+            help="notes/description for the task",
+            default=None,
+        )
+        subparser.add_argument(
             "-d",
             "--due",
             type=str,
@@ -87,6 +95,8 @@ class CreateTaskCommand(Command):
         task_args = {"title": args.title}
 
         # Prepare optional arguments
+        if args.notes:
+            task_args["notes"] = args.notes
         if args.due:
             task_args["due"] = args.due
         if args.snooze_until:

--- a/src/reclaim/commands/edit-task.py
+++ b/src/reclaim/commands/edit-task.py
@@ -30,6 +30,14 @@ class EditTaskCommand(Command):
             default=None,
         )
         subparser.add_argument(
+            "-n",
+            "--notes",
+            type=str,
+            metavar="<text>",
+            help="notes/description for the task",
+            default=None,
+        )
+        subparser.add_argument(
             "-d",
             "--due",
             type=str,
@@ -92,6 +100,8 @@ class EditTaskCommand(Command):
 
         if args.title:
             task.title = args.title
+        if args.notes is not None:
+            task.notes = args.notes
         if args.due:
             task.due = args.due
         if args.snooze_until:

--- a/src/reclaim/commands/show-task.py
+++ b/src/reclaim/commands/show-task.py
@@ -107,4 +107,8 @@ class ShowTaskCommand(Command):
         console = Console()
         console.print(f"Task {tid}: {task.title}", style="bold underline")
         console.print(grid)
+        if task.notes:
+            console.print()
+            console.print("Notes:", style="bold")
+            console.print(task.notes)
         return task


### PR DESCRIPTION
## Summary

The Reclaim.ai API supports task notes/descriptions via the `notes` field in the SDK, but the CLI didn't expose this functionality. This PR adds support for notes across the relevant commands.

### Changes

- Add `--notes`/`-n` option to `create-task` command
- Add `--notes`/`-n` option to `edit-task` command  
- Display notes in `show-task` output when present

### Example usage

```bash
# Create task with description
reclaim create "My task" -n "This is a detailed description of the task"

# Edit an existing task's notes
reclaim edit abc123 -n "Updated description"

# Show task displays notes at bottom
reclaim show abc123
```

### Output example

```
Task 76g6l: Test task with notes
   Status:          N2 (new)           Priority:     P2     
   ...

Notes:
This is a test description
```

## Test plan

- [x] Tested `reclaim create` with `-n` flag - notes saved correctly
- [x] Tested `reclaim edit` with `-n` flag - notes updated correctly
- [x] Tested `reclaim show` displays notes when present
- [x] Verified help text shows new options

🤖 Generated with [Claude Code](https://claude.com/claude-code)